### PR TITLE
Add !important to hidden opacity

### DIFF
--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -304,7 +304,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       }
       .hidden {
         visibility: hidden;
-        opacity: 0;
+        opacity: 0 !important;
         transition: visibility 0s 2s, opacity 2s linear;
         color: var(--success-lock-color);
       }


### PR DESCRIPTION
Opacity set in the #lock ID conflicted with the transition to hide the lock icon. Adding !important to opacity in the .hidden class forces `opacity: 0;` to take precedence and the fade-out transition works as expected.

This appears to resolve issue https://github.com/iantrich/restriction-card/issues/63