### PR TITLE
Remove z-index of overlay

### DIFF
--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -289,7 +289,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         right: 0;
         top: 0;
         bottom: 0;
-        z-index: 50;
         display: flex;
         color: var(--regular-lock-color);
       }


### PR DESCRIPTION
Fixes #86 - showing lock icon under pop-up window

Removed z-index, tested locally:

![lock](https://github.com/iantrich/restriction-card/assets/6704538/f45fc620-616d-4947-8bcf-b1b303826b87)
