### PR TITLE
Add overlay background

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,17 @@ resources:
 The following variables are available and can be set in your theme to change the appearance of the lock.
 Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically anything supported by CSS.
 
-| name                                    | Default              | Description                                             |
-| --------------------------------------- | -------------------- | ------------------------------------------------------- |
-| `restriction-regular-lock-color`        | `primary-text-color` | Lock color                                              |
-| `restriction-success-lock-color`        | `primary-color`      | Lock color when unlocked                                |
-| `restriction-blocked-lock-color`        | `error-state-color`  | Lock color when card is blocked                         |
-| `restriction-invalid--color`            | `error-state-color`  | Lock color after an invalid attempt to unlock           |
-| `restriction-lock-margin-left`          | `0px`                | Manually bump the left margin of the lock icon          |
-| `restriction-lock-row-margin-left`      | `24px`               | Manually bump the left margin of the lock icon in a row |
-| `restriction-lock-row-margin-top`       | `0px`                | Manually bump the top margin of the lock icon in a row  |
-| `restriction-lock-icon-size`            | `24px`               | Lock icon size                                          |
-| `restriction-lock-opacity`              | `0.5`                | Lock icon opacity                                       |
+| name                               | Default              | Description                                            |
+| ---------------------------------- | -------------------- | ------------------------------------------------------ |
+| `restriction-regular-lock-color`   | `primary-text-color` | Lock color                                             |
+| `restriction-success-lock-color`   | `primary-color`      | Lock color when unlocked                               |
+| `restriction-blocked-lock-color`   | `error-state-color`  | Lock color when card is blocked                        |
+| `restriction-invalid--color`       | `error-state-color`  | Lock color after an invalid attempt to unlock          |
+| `restriction-lock-margin-left`     | `0px`                | Manually bump the left margin of the lock icon         |
+| `restriction-lock-row-margin-left` | `24px`               | Manually bump the left margin of the lock icon in a row |
+| `restriction-lock-row-margin-top`  | `0px`                | Manually bump the top margin of the lock icon in a row |
+| `restriction-lock-icon-size`       | `24px`               | Lock icon size                                         |
+| `restriction-lock-opacity`         | `0.5`                | Lock icon opacity                                      |
 | `restriction-overlay-background`        | `unset`              | Overlay background when locked                          |
 | `restriction-overlay-row-outline`       | `none`               | Outline for an overlay in a row                         |
 | `restriction-overlay-row-border-radius` | `0`                  | Border radius for an overlay in a row                   |

--- a/README.md
+++ b/README.md
@@ -115,17 +115,20 @@ resources:
 The following variables are available and can be set in your theme to change the appearance of the lock.
 Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically anything supported by CSS.
 
-| name                               | Default              | Description                                            |
-| ---------------------------------- | -------------------- | ------------------------------------------------------ |
-| `restriction-regular-lock-color`   | `primary-text-color` | Lock color                                             |
-| `restriction-success-lock-color`   | `primary-color`      | Lock color when unlocked                               |
-| `restriction-blocked-lock-color`   | `error-state-color`  | Lock color when card is blocked                        |
-| `restriction-invalid--color`       | `error-state-color`  | Lock color after an invalid attempt to unlock          |
-| `restriction-lock-margin-left`     | `0px`                | Manually bump the left margin of the lock icon         |
-| `restriction-lock-row-margin-left` | `24px`               | Manually bump the left margin of the lock icon in rows |
-| `restriction-lock-row-margin-top`  | `0px`                | Manually bump the top margin of the lock icon in rows  |
-| `restriction-lock-icon-size`       | `24px`               | Lock icon size                                         |
-| `restriction-lock-opacity`         | `0.5`                | Lock icon opacity                                      |
+| name                                    | Default              | Description                                             |
+| --------------------------------------- | -------------------- | ------------------------------------------------------- |
+| `restriction-regular-lock-color`        | `primary-text-color` | Lock color                                              |
+| `restriction-success-lock-color`        | `primary-color`      | Lock color when unlocked                                |
+| `restriction-blocked-lock-color`        | `error-state-color`  | Lock color when card is blocked                         |
+| `restriction-invalid--color`            | `error-state-color`  | Lock color after an invalid attempt to unlock           |
+| `restriction-lock-margin-left`          | `0px`                | Manually bump the left margin of the lock icon          |
+| `restriction-lock-row-margin-left`      | `24px`               | Manually bump the left margin of the lock icon in a row |
+| `restriction-lock-row-margin-top`       | `0px`                | Manually bump the top margin of the lock icon in a row  |
+| `restriction-lock-icon-size`            | `24px`               | Lock icon size                                          |
+| `restriction-lock-opacity`              | `0.5`                | Lock icon opacity                                       |
+| `restriction-overlay-background`        | `unset`              | Overlay background when locked                          |
+| `restriction-overlay-row-outline`       | `none`               | Outline for an overlay in a row                         |
+| `restriction-overlay-row-border-radius` | `0`                  | Border radius for an overlay in a row                   |
 
 ## Example Configurations
 
@@ -183,7 +186,41 @@ entities:
   - entity: light.kitchen
 ```
 
+Overlay background example
+
+Card:
+
+![image](https://github.com/user-attachments/assets/10c14259-374e-4283-be33-6cf2a129507c)
+```yaml
+type: custom:restriction-card
+card:
+  type: button
+  entity: switch.test_switch
+```
+
+Row:
+
+![image](https://github.com/user-attachments/assets/93752506-b2df-44fa-ae66-b36bdd430f1d)
+```yaml
+type: entities
+entities:
+  - type: custom:restriction-card
+    row: true
+    card:
+      entity: switch.test_switch
+```
+
+Theme file:
+```yaml
+  restriction-overlay-background: repeating-linear-gradient( -45deg, transparent 0 10px,var(--user-restriction-card-mask,rgba(255,0,0,0.07)) 10px 20px)
+  restriction-lock-opacity: 0
+  restriction-overlay-row-border-radius: 4px
+  restriction-overlay-row-outline: 1px solid rgba(255,0,0,0.1)
+```
+
+
 Special Consideration for Input Selects:
+
 If you find that the restriction card is blocking something you don't want blocked like an input select, try adjusting the z-index using mod-card
 ```
 card:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 | `restriction-lock-icon-size`       | `24px`               | Lock icon size                                         |
 | `restriction-lock-opacity`         | `0.5`                | Lock icon opacity                                      |
 | `restriction-overlay-background`        | `unset`              | Overlay background when locked                          |
-| `restriction-overlay-row-outline`       | `none`               | Outline for an overlay in a row                         |
+| `restriction-overlay-row-outline`       | `none`               | Outline for an overlay in a row when locked             |
+| `restriction-overlay-background-blocked`  | `unset`            | Overlay background when blocked                         |
+| `restriction-overlay-row-outline-blocked` | `none`             | Outline for an overlay in a row when blocked            |
 | `restriction-overlay-row-border-radius` | `0`                  | Border radius for an overlay in a row                   |
 
 ## Example Configurations
@@ -188,17 +190,18 @@ entities:
 
 Overlay background example
 
-Card:
+Card locked:
 
-![image](https://github.com/user-attachments/assets/10c14259-374e-4283-be33-6cf2a129507c)
+![image](https://github.com/user-attachments/assets/54b64298-ba6f-4687-a704-e63dc2a1b11e)
 ```yaml
 type: custom:restriction-card
 card:
-  type: button
-  entity: switch.test_switch
+  type: entities
+  entities:
+    - entity: switch.test_switch
 ```
 
-Row:
+Row locked:
 
 ![image](https://github.com/user-attachments/assets/93752506-b2df-44fa-ae66-b36bdd430f1d)
 ```yaml
@@ -210,12 +213,41 @@ entities:
       entity: switch.test_switch
 ```
 
+Card blocked:
+
+![image](https://github.com/user-attachments/assets/a9336776-a2ea-4689-b801-fa43e64ab001)
+```yaml
+type: custom:restriction-card
+restrictions:
+  block: true
+card:
+  type: entities
+  entities:
+    - entity: switch.test_switch
+```
+
+Row blocked:
+
+![image](https://github.com/user-attachments/assets/0ea65870-45a5-4a60-9aa8-97ce8b697934)
+```yaml
+type: entities
+entities:
+  - type: custom:restriction-card
+    restrictions:
+      block: true
+    row: true
+    card:
+      entity: switch.test_switch
+```
+
 Theme file:
 ```yaml
   restriction-overlay-background: repeating-linear-gradient( -45deg, transparent 0 10px,var(--user-restriction-card-mask,rgba(255,0,0,0.07)) 10px 20px)
+  restriction-overlay-background-blocked: repeating-linear-gradient( -45deg, transparent 0 10px,var(--user-restriction-card-mask,rgba(127,127,127,0.07)) 10px 20px)
   restriction-lock-opacity: 0
   restriction-overlay-row-border-radius: 4px
   restriction-overlay-row-outline: 1px solid rgba(255,0,0,0.1)
+  restriction-overlay-row-outline-blocked: 1px solid rgba(127,127,127,0.1)
 ```
 
 

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -296,7 +296,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         display: flex;
         color: var(--regular-lock-color);
         background: var(--restriction-overlay-background, unset);
-        border-radius: var(--ha-card-border-radius, 12px);
       }
       #overlay:has(.hidden) {
         background: unset;
@@ -304,6 +303,15 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       #overlay:not(:has(.hidden)):has(+ #card.card-row) {
         outline: var(--restriction-overlay-row-outline, none);
         border-radius: var(--restriction-overlay-row-border-radius, 0);
+      }
+      #overlay:not(:has(+ #card.card-row)) {
+        border-radius: var(--ha-card-border-radius, 12px);
+      }
+      #overlay.blocked {
+        background: var(--restriction-overlay-background-blocked, unset);
+      }
+      #overlay.blocked:has(+ #card.card-row) {
+        outline: var(--restriction-overlay-row-outline-blocked, none);
       }
       #card {
         height: 100%;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -295,6 +295,11 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         z-index: 1;
         display: flex;
         color: var(--regular-lock-color);
+        background: var(--restriction-overlay-background, unset);
+        border-radius: var(--ha-card-border-radius, 12px);
+      }
+      #overlay:has(.hidden) {
+        background: unset;
       }
       #card {
         height: 100%;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -301,6 +301,10 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       #overlay:has(.hidden) {
         background: unset;
       }
+      #overlay:not(:has(.hidden)):has(+ #card.card-row) {
+        outline: var(--restriction-overlay-row-outline, none);
+        border-radius: var(--restriction-overlay-row-border-radius, 0);
+      }
       #card {
         height: 100%;
       }


### PR DESCRIPTION
Added a possibility a customize:
- overlay background when locked / blocked;
- outline for an overlay in a row when locked / blocked;
- border radius for an overlay in a row

New theme variables are introduced:
`restriction-overlay-background`
`restriction-overlay-background-blocked`
`restriction-overlay-row-outline`
`restriction-overlay-row-outline-blocked`
`restriction-overlay-row-border-radius`