### PR TITLE
feat: Background hides slowly

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,1 @@
-export const CARD_VERSION = '1.2.12';
+export const CARD_VERSION = '1.2.13';

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -296,7 +296,8 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         background: var(--restriction-overlay-background, unset);
       }
       #overlay:has(.hidden) {
-        background: unset;
+        opacity: 0 !important;
+        transition: opacity 2s linear;
       }
       #overlay:not(:has(.hidden)):has(+ #card.card-row) {
         outline: var(--restriction-overlay-row-outline, none);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -285,7 +285,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         --mdc-icon-size: var(--lock-icon-size);
       }
       #overlay {
-        align-items: flex-start;
         padding: 8px 7px;
         position: absolute;
         left: 0;


### PR DESCRIPTION
A "lock" icon is disappearing within some time interval.
This PR adds same "slow disappearing" for a overlay background (which can be customized since 1.2.11)