### PR TITLE
fix: still possible to toggle

### DIFF
--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -320,7 +320,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         height: 100%;
       }
       #overlay:not(:has(.hidden)) + #card.card-row {
-        overflow-y: clip;
+        overflow: clip;
       }
       .blocked {
         color: var(--blocked-lock-color) !important;


### PR DESCRIPTION
The red area was not "locked":

![изображение](https://github.com/user-attachments/assets/8aca1590-1a45-42b3-bff9-68a6d4a4cdb0)
