### PR TITLE
fix: RTL for icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 | `restriction-success-lock-color`   | `primary-color`      | Lock color when unlocked                               |
 | `restriction-blocked-lock-color`   | `error-state-color`  | Lock color when card is blocked                        |
 | `restriction-invalid--color`       | `error-state-color`  | Lock color after an invalid attempt to unlock          |
-| `restriction-lock-margin-left`     | `0px`                | Manually bump the left margin of the lock icon         |
-| `restriction-lock-row-margin-left` | `24px`               | Manually bump the left margin of the lock icon in a row |
+| `restriction-lock-margin-left`     | `0px`                | Manually bump the left margin of the lock icon (right for RTL)          |
+| `restriction-lock-row-margin-left` | `24px`               | Manually bump the left margin of the lock icon in a row (right for RTL) |
 | `restriction-lock-row-margin-top`  | `0px`                | Manually bump the top margin of the lock icon in a row |
 | `restriction-lock-icon-size`       | `24px`               | Lock icon size                                         |
 | `restriction-lock-opacity`         | `0.5`                | Lock icon opacity                                      |

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -326,11 +326,11 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         color: var(--blocked-lock-color) !important;
       }
       #lock {
-        margin-left: var(--lock-margin-left);
+        margin-inline-start: var(--lock-margin-left);
         opacity: var(--lock-opacity);
       }
       .row {
-        margin-left: var(--lock-row-margin-left) !important;
+        margin-inline-start: var(--lock-row-margin-left) !important;
         margin-top: var(--lock-row-margin-top) !important;
       }
       .hidden {


### PR DESCRIPTION
Before:

![изображение](https://github.com/user-attachments/assets/481a20f4-4e43-4f92-8fff-03210cc646ff)

After:

![изображение](https://github.com/user-attachments/assets/2e08ccc1-4e72-4236-ae83-461f79bf59a6)

```
type: vertical-stack
cards:
  - type: entities
    title: one row
    entities:
      - sun.sun
      - type: custom:restriction-card
        row: true
        card_mod:
          style: |
            :host {
              --restriction-lock-row-margin-left: 150px;
            }
        card:
          entity: input_boolean.test_boolean
          name: row
      - sun.sun
  - type: custom:mod-card
    card_mod:
      style:
        .: |
          :host {
            --restriction-lock-margin-left: 150px;
          }
    card:
      type: custom:restriction-card
      card:
        type: entities
        title: whole card
        entities:
          - entity: input_boolean.test_boolean
          - sun.sun
```