### PR TITLE
fix: margin-top for icon in "row: true"

### DIFF
--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -319,6 +319,9 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       #card {
         height: 100%;
       }
+      #overlay:not(:has(.hidden)) {
+        overflow: clip;
+      }
       #overlay:not(:has(.hidden)) + #card.card-row {
         overflow-y: clip;
       }
@@ -332,6 +335,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       .row {
         margin-left: var(--lock-row-margin-left) !important;
         margin-top: var(--lock-row-margin-top) !important;
+        position: inherit;
       }
       .hidden {
         visibility: hidden;


### PR DESCRIPTION
Warning:
icon should be vertically repositioned only within a row - otherwise it will be clipped:

![изображение](https://github.com/user-attachments/assets/57622e5f-4009-43eb-b08e-8506bdb76c73)
