### PR TITLE
fix: Various issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Cache Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 | `restriction-regular-lock-color`   | `primary-text-color` | Lock color                                             |
 | `restriction-success-lock-color`   | `primary-color`      | Lock color when unlocked                               |
 | `restriction-blocked-lock-color`   | `error-state-color`  | Lock color when card is blocked                        |
-| `restriction-invalid--color`       | `error-state-color`  | Lock color after an invalid attempt to unlock          |
+| `restriction-invalid-lock-color`       | `error-state-color`  | Lock color after an invalid attempt to unlock          |
 | `restriction-lock-margin-left`     | `0px`                | Manually bump the left margin of the lock icon (right for RTL)          |
 | `restriction-lock-row-margin-left` | `24px`               | Manually bump the left margin of the lock icon in a row (right for RTL) |
 | `restriction-lock-row-margin-top`  | `0px`                | Manually bump the top margin of the lock icon in a row |

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -368,6 +368,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       }
       #lock {
         margin-inline-start: var(--restriction-lock-margin-left, 0px);
+        margin-top: var(--restriction-lock-margin-top, 0px);
         opacity: var(--restriction-lock-opacity, 0.5);
         color: var(--restriction-regular-lock-color, var(--primary-text-color, #212121));
         position: inherit;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -116,10 +116,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                   'fill-available': true,
                 })}
               >
-                <div
-                  id="subContainer"
-                  class=${classMap({ 'fill-available': true })}
-                >
+                <div id="subContainer" class=${classMap({ 'fill-available': true })}>
                   <ha-icon
                     icon=${Boolean(this._unlocked)
                       ? this._config.unlocked_icon

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -343,6 +343,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       }
       #overlay:not(.unlocked) + #card.is-row {
         overflow: hidden;
+        pointer-events: none;
       }
       #lock {
         margin-inline-start: var(--restriction-lock-margin-left, 0px);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -321,7 +321,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       }
       #overlay.unlocked {
         opacity: 0 !important;
-        transition: opacity 2s linear;
+        transition: border-color 2s, opacity 2s linear;
       }
       #overlay.has-row.locked {
         border: var(--restriction-overlay-row-outline, none);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -78,7 +78,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     }
 
     let entity;
-    if !(this._hass && this._config) {
+    if (!this._hass || !this._config) {
       return false;
     } else if (this._config.condition && this._config.condition.entity) {
       entity = this._config.condition.entity;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -344,7 +344,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         overflow: clip;
       }
       #overlay:not(:has(.hidden)) + #card.card-row {
-        overflow: clip;
+        overflow: hidden;
       }
       .blocked {
         color: var(--blocked-lock-color) !important;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -216,10 +216,10 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         }
 
         lock.classList.add('icon-invalid');
-        overlay.classList.add('overlay-invalid');  /////////////////////////////////////////////////////////////
+        overlay.classList.add('overlay-invalid');
         window.setTimeout(() => {
           lock.classList.remove('icon-invalid');
-          overlay.classList.remove('overlay-invalid');  /////////////////////////////////////////////////////////////
+          overlay.classList.remove('overlay-invalid');
         }, 3000);
         return;
       }
@@ -255,7 +255,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
         if (conditionString || conditionArray) {
           lock.classList.add('icon-invalid');
-          overlay.classList.add('overlay-invalid');  ///////////////////////////////////////////////////////
+          overlay.classList.add('overlay-invalid');
           this._delay = Boolean(this._config.restrictions.pin.retry_delay);
           if (this._config.restrictions.pin.max_retries) {
             this._retries++;
@@ -267,7 +267,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
             window.setTimeout(
               () => {
                 lock.classList.remove('icon-invalid');
-                overlay.classList.remove('overlay-invalid');  ////////////////////////////////////////////////////////
+                overlay.classList.remove('overlay-invalid');
                 this._retries = 0;
                 this._maxed = false;
                 this._delay = false;
@@ -283,7 +283,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
                 if (!this._maxed) {
                   lock.classList.remove('icon-invalid');
-                  overlay.classList.remove('overlay-invalid');  ////////////////////////////////////////////////////////
+                  overlay.classList.remove('overlay-invalid');
                 }
               },
               this._config.restrictions.pin.retry_delay ? this._config.restrictions.pin.retry_delay * 1000 : 3000,

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -115,6 +115,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                   'has-row': Boolean(this._config.row),
                 })}
               >
+              <div id="subContainer">
                 <ha-icon
                   icon=${Boolean(this._unlocked)
                     ? this._config.unlocked_icon
@@ -127,6 +128,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                     'icon-in-row': Boolean(this._config.row),
                   })}
                 ></ha-icon>
+                </div>  
               </div>
             `}
         ${this.renderCard(this._config.card)}
@@ -316,22 +318,25 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         top: 0;
         bottom: 0;
         z-index: 1;
+      }
+      #subContainer {
+        height: 100%;
         border-radius: var(--ha-card-border-radius, 12px);
         background: var(--restriction-overlay-background, unset);
       }
-      #overlay.has-row {
+      #overlay.has-row #subContainer {
         border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
         border: var(--restriction-overlay-row-outline, none);
       }
-      #overlay.unlocked {
+      #overlay.unlocked #subContainer {
         border-color: transparent;
         opacity: 0 !important;
         transition: border-color 2s, opacity 2s linear;
       }
-      #overlay.blocked {
+      #overlay.blocked #subContainer {
         background: var(--restriction-overlay-background-blocked, unset) !important;
       }
-      #overlay.has-row.blocked {
+      #overlay.has-row.blocked #subContainer {
         border: var(--restriction-overlay-row-outline-blocked, none);
         border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
       }
@@ -342,8 +347,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         overflow: hidden;
       }
       #overlay:not(.unlocked) + #card.is-row {
-        overflow: hidden;
-        pointer-events: none;
+        overflow: hidden; /********************************************************************************/
       }
       #lock {
         margin-inline-start: var(--restriction-lock-margin-left, 0px);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -110,7 +110,9 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 id="overlay"
                 class=${classMap({
                   locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
-                  blocked: Boolean(this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false),
+                  blocked: Boolean(
+                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false
+                  ),
                   'has-row': Boolean(this._config.row),
                   'fill-available': true,
                 })}
@@ -124,7 +126,9 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                       : this._config.locked_icon}
                     id="lock"
                     class=${classMap({
-                      'icon-blocked': Boolean(this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false),
+                      'icon-blocked': Boolean(
+                        this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false
+                      ),
                       'icon-in-row': Boolean(this._config.row),
                     })}
                   ></ha-icon>

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -117,10 +117,10 @@ class RestrictionCard extends LitElement implements LovelaceCard {
               >
                 <ha-icon
                   icon=${Boolean(this._unlocked)
-                    ? this._config.unlocked_icon!
+                    ? this._config.unlocked_icon
                       ? this._config.unlocked_icon
-                      : this._config.locked_icon!
-                    : this._config.locked_icon!}
+                      : this._config.locked_icon
+                    : this._config.locked_icon}
                   id="lock"
                   class=${classMap({
                     'icon-blocked': Boolean(isBlocked),
@@ -277,7 +277,8 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     this._unlocked = true;
     const overlay = this.shadowRoot.getElementById('overlay') as LitElement;
     overlay.style.setProperty('pointer-events', 'none');
-    if (!this._config.unlocked_icon) {
+    const useUnlockedIcon = Boolean(this._config.unlocked_icon?);
+    if (!useUnlockedIcon) {
       lock.classList.add('icon-hidden');
     }
     overlay.classList.add('unlocked');
@@ -286,7 +287,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     window.setTimeout(() => {
       this._unlocked = false;
       overlay.style.setProperty('pointer-events', '');
-      if (!this._config.unlocked_icon) {
+      if (!useUnlockedIcon) {
         lock.classList.remove('icon-hidden');
       }
       overlay.classList.remove('unlocked');

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -93,7 +93,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       return html``;
     }
 
-    const isBlocked = this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false;
     return html`
       <div id="mainContainer">
         ${(this._config.exemptions &&
@@ -111,7 +110,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 id="overlay"
                 class=${classMap({
                   locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
-                  blocked: Boolean(isBlocked),
+                  blocked: Boolean(this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false),
                   'has-row': Boolean(this._config.row),
                   'fill-available': true,
                 })}
@@ -125,7 +124,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                       : this._config.locked_icon}
                     id="lock"
                     class=${classMap({
-                      'icon-blocked': Boolean(isBlocked),
+                      'icon-blocked': Boolean(this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false),
                       'icon-in-row': Boolean(this._config.row),
                     })}
                   ></ha-icon>

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -320,6 +320,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         background: var(--restriction-overlay-background, unset);
       }
       #overlay.unlocked {
+        border-color: transparent;
         opacity: 0 !important;
         transition: border-color 2s, opacity 2s linear;
       }

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -93,6 +93,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       return html``;
     }
 
+    const isBlocked = this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false;
     return html`
       <div id="mainContainer">
         ${(this._config.exemptions &&
@@ -109,14 +110,8 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 })}
                 id="overlay"
                 class=${classMap({
-                  locked:
-                    !Boolean(this._unlocked) &&
-                    !Boolean(
-                      this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
-                    ),
-                  blocked: Boolean(
-                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
-                  ),
+                  locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
+                  blocked: Boolean(isBlocked),
                   'has-row': Boolean(this._config.row),
                   'fill-available': true,
                 })}
@@ -130,9 +125,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                       : this._config.locked_icon}
                     id="lock"
                     class=${classMap({
-                      'icon-blocked': Boolean(
-                        this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
-                      ),
+                      'icon-blocked': Boolean(isBlocked),
                       'icon-in-row': Boolean(this._config.row),
                     })}
                   ></ha-icon>

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -109,9 +109,12 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 })}
                 id="overlay"
                 class=${classMap({
-                  locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
+                  locked: !Boolean(this._unlocked) && !Boolean(
+                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
+                  ),
                   blocked: Boolean(
-                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false),
+                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
+                  ),
                   'has-row': Boolean(this._config.row),
                   'fill-available': true,
                 })}
@@ -126,7 +129,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                     id="lock"
                     class=${classMap({
                       'icon-blocked': Boolean(
-                        this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false
+                        this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
                       ),
                       'icon-in-row': Boolean(this._config.row),
                     })}

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -277,7 +277,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     this._unlocked = true;
     const overlay = this.shadowRoot.getElementById('overlay') as LitElement;
     overlay.style.setProperty('pointer-events', 'none');
-    const useUnlockedIcon = Boolean(this._config.unlocked_icon?);
+    const useUnlockedIcon = Boolean(this._config.unlocked_icon!);
     if (!useUnlockedIcon) {
       lock.classList.add('icon-hidden');
     }

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -111,8 +111,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 class=${classMap({
                   locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
                   blocked: Boolean(
-                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false
-                  ),
+                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false),
                   'has-row': Boolean(this._config.row),
                   'fill-available': true,
                 })}

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -311,7 +311,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         --mdc-icon-size: var(--lock-icon-size);
       }
       #overlay {
-        padding: 8px 7px;
         position: absolute;
         left: 0;
         right: 0;
@@ -321,6 +320,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       }
       #subContainer {
         height: 100%;
+        padding: 8px 7px;
         border-radius: var(--ha-card-border-radius, 12px);
         background: var(--restriction-overlay-background, unset);
       }

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -207,6 +207,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     }
 
     const lock = this.shadowRoot.getElementById('lock') as LitElement;
+    const overlay = this.shadowRoot.getElementById('overlay') as LitElement;
 
     if (this._config.restrictions) {
       if (this._config.restrictions.block && this._matchRestriction(this._config.restrictions.block)) {
@@ -215,8 +216,10 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         }
 
         lock.classList.add('icon-invalid');
+        overlay.classList.add('overlay-invalid');  /////////////////////////////////////////////////////////////
         window.setTimeout(() => {
           lock.classList.remove('icon-invalid');
+          overlay.classList.remove('overlay-invalid');  /////////////////////////////////////////////////////////////
         }, 3000);
         return;
       }
@@ -252,6 +255,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
         if (conditionString || conditionArray) {
           lock.classList.add('icon-invalid');
+          overlay.classList.add('overlay-invalid');  ///////////////////////////////////////////////////////
           this._delay = Boolean(this._config.restrictions.pin.retry_delay);
           if (this._config.restrictions.pin.max_retries) {
             this._retries++;
@@ -263,6 +267,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
             window.setTimeout(
               () => {
                 lock.classList.remove('icon-invalid');
+                overlay.classList.remove('overlay-invalid');  ////////////////////////////////////////////////////////
                 this._retries = 0;
                 this._maxed = false;
                 this._delay = false;
@@ -278,6 +283,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
                 if (!this._maxed) {
                   lock.classList.remove('icon-invalid');
+                  overlay.classList.remove('overlay-invalid');  ////////////////////////////////////////////////////////
                 }
               },
               this._config.restrictions.pin.retry_delay ? this._config.restrictions.pin.retry_delay * 1000 : 3000,
@@ -298,7 +304,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     }
 
     this._unlocked = true;
-    const overlay = this.shadowRoot.getElementById('overlay') as LitElement;
     overlay.style.setProperty('pointer-events', 'none');
     lock.classList.add('icon-hidden');
     overlay.classList.add('unlocked');
@@ -390,6 +395,9 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       .icon-invalid {
         animation: blinker 1s linear infinite;
         color: var(--restriction-invalid-lock-color, var(--error-state-color, #db4437)) !important;
+      }
+      .overlay-invalid {
+        animation: blinker 1s linear infinite;
       }
       @keyframes blinker {
         50% {

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -317,8 +317,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         bottom: 0;
         z-index: 1;
         border-radius: var(--ha-card-border-radius, 12px);
-      }
-      #overlay.locked {
         background: var(--restriction-overlay-background, unset);
       }
       #overlay.unlocked {
@@ -330,7 +328,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
       }
       #overlay.blocked {
-        background: var(--restriction-overlay-background-blocked, unset);
+        background: var(--restriction-overlay-background-blocked, unset) !important;
       }
       #overlay.has-row.blocked {
         border: var(--restriction-overlay-row-outline-blocked, none);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -319,14 +319,14 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         border-radius: var(--ha-card-border-radius, 12px);
         background: var(--restriction-overlay-background, unset);
       }
+      #overlay.has-row {
+        border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
+        border: var(--restriction-overlay-row-outline, none);
+      }
       #overlay.unlocked {
         border-color: transparent;
         opacity: 0 !important;
         transition: border-color 2s, opacity 2s linear;
-      }
-      #overlay.has-row.locked {
-        border: var(--restriction-overlay-row-outline, none);
-        border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
       }
       #overlay.blocked {
         background: var(--restriction-overlay-background-blocked, unset) !important;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -112,7 +112,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 class=${classMap({
                   locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
                   blocked: Boolean(isBlocked),
-                  "has-row": Boolean(this._config.row),
+                  'has-row': Boolean(this._config.row),
                 })}
               >
                 <ha-icon
@@ -123,8 +123,8 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                     : this._config.locked_icon!}
                   id="lock"
                   class=${classMap({
-                    "icon-blocked": Boolean(isBlocked),
-                    "icon-in-row": Boolean(this._config.row),
+                    'icon-blocked': Boolean(isBlocked),
+                    'icon-in-row': Boolean(this._config.row),
                   })}
                 ></ha-icon>
               </div>

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -77,8 +77,18 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       return true;
     }
 
-    if (this._hass && this._config && this._config.condition && this._config.condition.entity) {
-      return oldHass.states[this._config.condition.entity] !== this._hass.states[this._config.condition.entity];
+    let entity;
+    if !(this._hass && this._config) {
+      return false;
+    } else if (this._config.condition && this._config.condition.entity) {
+      entity = this._config.condition.entity;
+      return oldHass.states[entity] !== this._hass.states[entity];
+    } else if (this._config.restrictions.block.condition && this._config.restrictions.block.condition.entity) {
+      entity = this._config.restrictions.block.condition.entity;
+      return oldHass.states[entity] !== this._hass.states[entity];
+    } else if (this._config.restrictions.hide.condition && this._config.restrictions.hide.condition.entity) {
+      entity = this._config.restrictions.hide.condition.entity;
+      return oldHass.states[entity] !== this._hass.states[entity];
     } else {
       return false;
     }

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -83,10 +83,12 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     } else if (this._config.condition && this._config.condition.entity) {
       entity = this._config.condition.entity;
       return oldHass.states[entity] !== this._hass.states[entity];
-    } else if (this._config.restrictions.block.condition && this._config.restrictions.block.condition.entity) {
+    } else if (!this._config.restrictions) {
+      return false;
+    } else if (this._config.restrictions.block && this._config.restrictions.block.condition && this._config.restrictions.block.condition.entity) {
       entity = this._config.restrictions.block.condition.entity;
       return oldHass.states[entity] !== this._hass.states[entity];
-    } else if (this._config.restrictions.hide.condition && this._config.restrictions.hide.condition.entity) {
+    } else if (this._config.restrictions.hide && this._config.restrictions.hide.condition && this._config.restrictions.hide.condition.entity) {
       entity = this._config.restrictions.hide.condition.entity;
       return oldHass.states[entity] !== this._hass.states[entity];
     } else {

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -109,9 +109,11 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                 })}
                 id="overlay"
                 class=${classMap({
-                  locked: !Boolean(this._unlocked) && !Boolean(
-                    this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
-                  ),
+                  locked:
+                    !Boolean(this._unlocked) &&
+                    !Boolean(
+                      this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
+                    ),
                   blocked: Boolean(
                     this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false,
                   ),

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -128,7 +128,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                       'icon-in-row': Boolean(this._config.row),
                     })}
                   ></ha-icon>
-                </div>  
+                </div>
               </div>
             `}
         ${this.renderCard(this._config.card)}

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -355,11 +355,11 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         margin-inline-start: var(--restriction-lock-margin-left, 0px);
         opacity: var(--restriction-lock-opacity, 0.5);
         color: var(--restriction-regular-lock-color, var(--primary-text-color, #212121));
+        position: inherit;
       }
       .icon-in-row {
         margin-inline-start: var(--restriction-lock-row-margin-left, 24px) !important;
         margin-top: var(--restriction-lock-row-margin-top, 0px) !important;
-        position: inherit;
       }
       .icon-hidden {
         opacity: 0 !important;

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -113,9 +113,13 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                   locked: !Boolean(this._unlocked) && !Boolean(isBlocked),
                   blocked: Boolean(isBlocked),
                   'has-row': Boolean(this._config.row),
+                  'fill-available': true,
                 })}
               >
-                <div id="subContainer">
+                <div
+                  id="subContainer"
+                  class=${classMap({ 'fill-available': true })}
+                >
                   <ha-icon
                     icon=${Boolean(this._unlocked)
                       ? this._config.unlocked_icon
@@ -310,16 +314,17 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       ha-icon {
         --mdc-icon-size: var(--lock-icon-size);
       }
-      #overlay {
+      .fill-available {
         position: absolute;
         left: 0;
         right: 0;
         top: 0;
         bottom: 0;
+      }
+      #overlay {
         z-index: 1;
       }
       #subContainer {
-        height: 100%;
         padding: 8px 7px;
         border-radius: var(--ha-card-border-radius, 12px);
         background: var(--restriction-overlay-background, unset);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -280,19 +280,14 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     this._unlocked = true;
     const overlay = this.shadowRoot.getElementById('overlay') as LitElement;
     overlay.style.setProperty('pointer-events', 'none');
-    const useUnlockedIcon = Boolean(this._config.unlocked_icon!);
-    if (!useUnlockedIcon) {
-      lock.classList.add('icon-hidden');
-    }
+    lock.classList.add('icon-hidden');
     overlay.classList.add('unlocked');
     overlay.classList.remove('locked');
 
     window.setTimeout(() => {
       this._unlocked = false;
       overlay.style.setProperty('pointer-events', '');
-      if (!useUnlockedIcon) {
-        lock.classList.remove('icon-hidden');
-      }
+      lock.classList.remove('icon-hidden');
       overlay.classList.remove('unlocked');
       overlay.classList.add('locked');
     }, this._config.duration * 1000);

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -85,10 +85,18 @@ class RestrictionCard extends LitElement implements LovelaceCard {
       return oldHass.states[entity] !== this._hass.states[entity];
     } else if (!this._config.restrictions) {
       return false;
-    } else if (this._config.restrictions.block && this._config.restrictions.block.condition && this._config.restrictions.block.condition.entity) {
+    } else if (
+      this._config.restrictions.block &&
+      this._config.restrictions.block.condition &&
+      this._config.restrictions.block.condition.entity
+    ) {
       entity = this._config.restrictions.block.condition.entity;
       return oldHass.states[entity] !== this._hass.states[entity];
-    } else if (this._config.restrictions.hide && this._config.restrictions.hide.condition && this._config.restrictions.hide.condition.entity) {
+    } else if (
+      this._config.restrictions.hide &&
+      this._config.restrictions.hide.condition &&
+      this._config.restrictions.hide.condition.entity
+    ) {
       entity = this._config.restrictions.hide.condition.entity;
       return oldHass.states[entity] !== this._hass.states[entity];
     } else {

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -326,14 +326,14 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         transition: opacity 2s linear;
       }
       #overlay.has-row.locked {
-        outline: var(--restriction-overlay-row-outline, none);
+        border: var(--restriction-overlay-row-outline, none);
         border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
       }
       #overlay.blocked {
         background: var(--restriction-overlay-background-blocked, unset);
       }
       #overlay.has-row.blocked {
-        outline: var(--restriction-overlay-row-outline-blocked, none);
+        border: var(--restriction-overlay-row-outline-blocked, none);
         border-radius: var(--restriction-overlay-row-border-radius, 0) !important;
       }
       #card {

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -115,19 +115,19 @@ class RestrictionCard extends LitElement implements LovelaceCard {
                   'has-row': Boolean(this._config.row),
                 })}
               >
-              <div id="subContainer">
-                <ha-icon
-                  icon=${Boolean(this._unlocked)
-                    ? this._config.unlocked_icon
+                <div id="subContainer">
+                  <ha-icon
+                    icon=${Boolean(this._unlocked)
                       ? this._config.unlocked_icon
-                      : this._config.locked_icon
-                    : this._config.locked_icon}
-                  id="lock"
-                  class=${classMap({
-                    'icon-blocked': Boolean(isBlocked),
-                    'icon-in-row': Boolean(this._config.row),
-                  })}
-                ></ha-icon>
+                        ? this._config.unlocked_icon
+                        : this._config.locked_icon
+                      : this._config.locked_icon}
+                    id="lock"
+                    class=${classMap({
+                      'icon-blocked': Boolean(isBlocked),
+                      'icon-in-row': Boolean(this._config.row),
+                    })}
+                  ></ha-icon>
                 </div>  
               </div>
             `}
@@ -347,7 +347,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         overflow: hidden;
       }
       #overlay:not(.unlocked) + #card.is-row {
-        overflow: hidden; /********************************************************************************/
+        overflow: hidden;
       }
       #lock {
         margin-inline-start: var(--restriction-lock-margin-left, 0px);


### PR DESCRIPTION
1. (iOS fixes) Use classes instead of "has()" selectors (iOS devices & old Macs do not process some code properly).
2. (iOS fixes) Use `border` instead of `outline` due to a bug in old versions of Safari.
3. Add `--restriction-lock-margin-top` variable.
4. Fix `--restriction-invalid-lock-color` variable name.
5. Fix preventing access to a toggle if a `restriction-overlay-row-border-radius` is defined.
6. Add a transition for an outline for a row (disappears slowly like a "lock" icon).
7. Add an update if `condition` entity for `block` or `hide` was changed.
8. Add blinking to a custom background & outline.
9. Various cleanups.