### PR TITLE
feat: "css_variables" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ resources:
 | action        | string  | **Optional** | Action type to trigger the unlock. Options are `tap`, `double_tap`, or `hold`. Default is `tap` |
 | locked_icon   | string  | **Optional** | Icon to show when locked. Default is `mdi:lock-outline`                                         |
 | unlocked_icon | string  | **Optional** | Icon to show when unlocked instead of fading the icon away                                      |
-| css_variables | string  | **Optional** | Set to override default theme variables. See [css_variables example](#css_variables-example)    |
+| css_variables | map     | **Optional** | Set to override default theme variables. See [css_variables option](#css_variables-option)    |
 
 ## Restrictions options
 
@@ -136,21 +136,17 @@ Colors can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basica
 
 Note: it is not recommended to set negative values for `*-lock-*-margin-*` variables to prevent a "lock" icon to be clipped.
 
-## css_variables example
+## css_variables option
 
-The `css_variables` can be used to override default values of supported [theme variables](#theme-variables).
+The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
 Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
-A value of `css_variables` option must represent a string with values of supported theme variables, each value ended with a semicolon:
+Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name a variable w/o leading `--` dashes, with `_` undescores instead other `-` dashes, see an example below:
 ```
-css_variables: "--restriction-regular-lock-color: red;--restriction-success-lock-color;"
+css_variables:
+  restriction_regular_lock_color: red
+  restriction_success_lock_color: cyan
 ```
-Yaml-multiline notation can be used for long values:
-```
-css_variables: >-
-  --restriction-regular-lock-color: red;
-  --restriction-success-lock-color: cyan;
-```
-Jinja templates are not supported, use card-mod if you need templates.
+Note: jinja templates are not supported, use card-mod if you need templates.
 
 ## Example configurations
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Note: it is not recommended to set negative values for `*-lock-*-margin-*` varia
 
 The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
 Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
-Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name of a variable (prefixed by `--`), see an example below:
+Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name of a variable prefixed by `--`, see an example below:
 ```
 css_variables:
   --restriction-regular-lock-color: red

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Note: it is not recommended to set negative values for `*-lock-*-margin-*` varia
 
 The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
 Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
-Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name of a variable, see an example below:
+Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name of a variable (prefixed by `--`), see an example below:
 ```
 css_variables:
   --restriction-regular-lock-color: red

--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ resources:
 | Name          | Type    | Requirement  | Description                                                                                     |
 | ------------- | ------- | ------------ | ----------------------------------------------------------------------------------------------- |
 | type          | string  | **Required** | `custom:restriction-card`                                                                       |
-| card          | map     | **Required** | Card to render within `restriction-card`.                                                       |
-| restrictions  | map     | **Optional** | Additional restrictions. See [Restrictions Options](#restrictions-options).                     |
-| exemptions    | list    | **Optional** | List of exemption objects. See [Exemption Options](#exemption-options).                         |
-| condition     | map     | **Optional** | Conditional object to make lock active. See [Condition Options](#condition-options).            |
+| card          | map     | **Required** | Card to render within `restriction-card`                                                        |
+| restrictions  | map     | **Optional** | Additional restrictions. See [Restrictions Options](#restrictions-options)                      |
+| exemptions    | list    | **Optional** | List of exemption objects. See [Exemption Options](#exemption-options)                          |
+| condition     | map     | **Optional** | Conditional object to make lock active. See [Condition Options](#condition-options)             |
 | row           | boolean | **Optional** | Set to true to give a default `margin:left: 24px`                                               |
 | duration      | number  | **Optional** | Duration of unlock in seconds. Default is `5`                                                   |
 | action        | string  | **Optional** | Action type to trigger the unlock. Options are `tap`, `double_tap`, or `hold`. Default is `tap` |
 | locked_icon   | string  | **Optional** | Icon to show when locked. Default is `mdi:lock-outline`                                         |
 | unlocked_icon | string  | **Optional** | Icon to show when unlocked instead of fading the icon away                                      |
+| css_variables | string  | **Optional** | Set to override default theme variables. See [css_variables example](#css_variables-example)    |
 
-## Restrictions Options
+## Restrictions options
 
 | Name    | Type | Requirement  | Description                                                               |
 | ------- | ---- | ------------ | ------------------------------------------------------------------------- |
@@ -60,7 +61,7 @@ resources:
 | block   | map  | **Optional** | Block interaction restriction. See [Block Options](#block-options).       |
 | hide    | map  | **Optional** | Hide card restriction. See [Hide Options](#hide-options)..                |
 
-## Confirm Options
+## Confirm options
 
 | Name       | Type   | Requirement  | Description                                                                                 |
 | ---------- | ------ | ------------ | ------------------------------------------------------------------------------------------- |
@@ -68,7 +69,7 @@ resources:
 | exemptions | list   | **Optional** | List of exemption objects. See [Exemption Options](#exemption-options).                     |
 | condition  | map    | **Optional** | Conditional object to make restriction active. See [Condition Options](#condition-options). |
 
-## Pin Options
+## Pin options
 
 | Name              | Type   | Requirement  | Description                                                                                                               |
 | ----------------- | ------ | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
@@ -80,7 +81,7 @@ resources:
 | max_retries       | number | **Optional** | Number of consecutive invalid retries allowed before blocking for the `max_retries_delay` seconds. Default is `unlimited` |
 | max_retries_delay | number | **Optional** | Number of seconds to block attempts to unlock after the `max_retries` has been reached                                    |
 
-## Block Options
+## Block options
 
 | Name       | Type   | Requirement  | Description                                                                                 |
 | ---------- | ------ | ------------ | ------------------------------------------------------------------------------------------- |
@@ -88,20 +89,20 @@ resources:
 | exemptions | list   | **Optional** | List of exemption objects. See [Exemption Options](#exemption-options).                     |
 | condition  | map    | **Optional** | Conditional object to make restriction active. See [Condition Options](#condition-options). |
 
-## Hide Options
+## Hide options
 
 | Name       | Type | Requirement  | Description                                                                                 |
 | ---------- | ---- | ------------ | ------------------------------------------------------------------------------------------- |
 | exemptions | list | **Optional** | List of exemption objects. See [Exemption Options](#exemption-options).                     |
 | condition  | map  | **Optional** | Conditional object to make restriction active. See [Condition Options](#condition-options). |
 
-## Exemption Options
+## Exemption options
 
 | Name | Type   | Requirement  | Description                                                |
 | ---- | ------ | ------------ | ---------------------------------------------------------- |
 | user | string | **Required** | User id to exempt. This is found in the user profile `ID`. |
 
-## Condition Options
+## Condition options
 
 | Name      | Type   | Requirement  | Description                                                                                         |
 | --------- | ------ | ------------ | --------------------------------------------------------------------------------------------------- |
@@ -110,10 +111,10 @@ resources:
 | attribute | string | **Optional** | Attribute of the entity to use instead of the state.                                                |
 | operator  | string | **Optional** | Operator to use in the comparison. Can be `==`,`<=`,`<`,`>=`,`>`,`!=`, or `regex`. Default is `==`. |
 
-## Theme Variables
+## Theme variables
 
-The following variables are available and can be set in your theme to change the appearance of the lock.
-Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically anything supported by CSS.
+The following variables are available and can be set in your theme to change the appearance of the restriction-card.
+Colors can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically anything supported by CSS.
 
 | name                               | Default              | Description                                            |
 | ---------------------------------- | -------------------- | ------------------------------------------------------ |
@@ -135,10 +136,25 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 
 Note: it is not recommended to set negative values for `*-lock-*-margin-*` variables to prevent a "lock" icon to be clipped.
 
+## css_variables example
 
-## Example Configurations
+The `css_variables` can be used to override default values of supported [theme variables](#theme-variables).
+Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
+A value of `css_variables` option must represent a string with values of supported theme variables, each value ended with a semicolon:
+```
+css_variables: "--restriction-regular-lock-color: red;--restriction-success-lock-color;"
+```
+Yaml-multiline notation can be used for long values:
+```
+css_variables: >-
+  --restriction-regular-lock-color: red;
+  --restriction-success-lock-color: cyan;
+```
+Jinja templates are not supported, use card-mod if you need templates.
 
-Simple Lock example
+## Example configurations
+
+Simple lock example
 
 ![lock](lock.gif)
 
@@ -275,7 +291,7 @@ Notes:
 
 ---
 
-Special Consideration for Input Selects:
+Special consideration for `input_select` entities:
 
 If you find that the restriction card is blocking something you don't want blocked like an input select, try adjusting the z-index using mod-card
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Note: it is not recommended to set negative values for `*-lock-*-margin-*` varia
 ## css_variables option
 
 The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
-Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
+Alternatively, these variables can be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
 Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name of a variable prefixed by `--`, see an example below:
 ```
 css_variables:

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ Note: it is not recommended to set negative values for `*-lock-*-margin-*` varia
 
 The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
 Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
-Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name a variable w/o leading `--` dashes (like these varaibles can be defined in a custom theme), see an example below:
+Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name a variable, see an example below:
 ```
 css_variables:
-  restriction-regular-lock-color: red
-  restriction-success-lock-color: cyan
+  --restriction-regular-lock-color: red
+  --restriction-success-lock-color: cyan
 ```
 Note: jinja templates are not supported, use card-mod if you need templates.
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ Note: it is not recommended to set negative values for `*-lock-*-margin-*` varia
 
 The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
 Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
-Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name a variable w/o leading `--` dashes, with `_` undescores instead other `-` dashes, see an example below:
+Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name a variable w/o leading `--` dashes (like these varaibles can be defined in a custom theme), see an example below:
 ```
 css_variables:
-  restriction_regular_lock_color: red
-  restriction_success_lock_color: cyan
+  restriction-regular-lock-color: red
+  restriction-success-lock-color: cyan
 ```
 Note: jinja templates are not supported, use card-mod if you need templates.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Note: it is not recommended to set negative values for `*-lock-*-margin-*` varia
 
 The `css_variables` option can be used to override default values of supported [theme variables](#theme-variables).
 Alternatively, these variables may be defined in a custom Frontend theme or by [card-mod](https://github.com/thomasloven/lovelace-card-mod) locally.
-Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name a variable, see an example below:
+Each entry in `css_variables` option must represent a "name: value" pair for a variable which should be overridden where `name` is a name of a variable, see an example below:
 ```
 css_variables:
   --restriction-regular-lock-color: red

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   "author": "Ian Richardson <iantrich@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "custom-card-helpers": "^1.9.0",
+    "custom-card-helpers": "^1.6.4",
     "home-assistant-js-websocket": "^4.4.0",
-    "lit": "^2.6.1"    
+    "lit-element": "^2.3.1",
+    "lit-html": "^1.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,9 @@
   "author": "Ian Richardson <iantrich@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "custom-card-helpers": "^1.6.4",
+    "custom-card-helpers": "^1.9.0",
     "home-assistant-js-websocket": "^4.4.0",
-    "lit-element": "^2.3.1",
-    "lit-html": "^1.2.1"
+    "lit": "^2.6.1"    
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TemplateResult, customElement, LitElement, property, html, CSSResult, css, PropertyValues } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
+import { TemplateResult, customElement, LitElement, property, html, CSSResult, css, PropertyValues } from 'lit';
+import { classMap } from 'lit/directives/class-map';
+import { styleMap } from 'lit/directives/style-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { RestrictionCardConfig } from './types';
 import { HomeAssistant, LovelaceCard, computeCardSize, LovelaceCardConfig, evaluateFilter } from 'custom-card-helpers';

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TemplateResult, customElement, LitElement, property, html, CSSResult, css, PropertyValues } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
-import { ifDefined } from "lit/directives/if-defined.js";
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { RestrictionCardConfig } from './types';
 import { HomeAssistant, LovelaceCard, computeCardSize, LovelaceCardConfig, evaluateFilter } from 'custom-card-helpers';
 import { CARD_VERSION } from './const';

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -115,9 +115,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
     const isBlocked = this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false;
     return html`
-      <div id="mainContainer"
-        style=${ifDefined(styleMap(this._config.css_variables || {}))}
-      >
+      <div id="mainContainer" style=${ifDefined(styleMap(this._config.css_variables || {}))}>
         ${(this._config.exemptions &&
           this._config.exemptions.some(e => (this._hass && this._hass.user ? e.user === this._hass.user.id : false))) ||
         (this._config.condition &&

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TemplateResult, customElement, LitElement, property, html, CSSResult, css, PropertyValues } from 'lit';
-import { classMap } from 'lit/directives/class-map';
-import { styleMap } from 'lit/directives/style-map.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
+import { TemplateResult, customElement, LitElement, property, html, CSSResult, css, PropertyValues } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
+import { styleMap } from 'lit-html/directives/style-map.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RestrictionCardConfig } from './types';
 import { HomeAssistant, LovelaceCard, computeCardSize, LovelaceCardConfig, evaluateFilter } from 'custom-card-helpers';
 import { CARD_VERSION } from './const';

--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TemplateResult, customElement, LitElement, property, html, CSSResult, css, PropertyValues } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
-
+import { ifDefined } from "lit/directives/if-defined.js";
 import { RestrictionCardConfig } from './types';
 import { HomeAssistant, LovelaceCard, computeCardSize, LovelaceCardConfig, evaluateFilter } from 'custom-card-helpers';
 import { CARD_VERSION } from './const';
@@ -115,7 +115,9 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
     const isBlocked = this._config.restrictions ? this._matchRestriction(this._config.restrictions.block) : false;
     return html`
-      <div id="mainContainer">
+      <div id="mainContainer"
+        style=${ifDefined(styleMap(this._config.css_variables || {}))}
+      >
         ${(this._config.exemptions &&
           this._config.exemptions.some(e => (this._hass && this._hass.user ? e.user === this._hass.user.id : false))) ||
         (this._config.condition &&
@@ -322,7 +324,6 @@ class RestrictionCard extends LitElement implements LovelaceCard {
     return css`
       :host {
         position: relative;
-        --lock-icon-size: var(--restriction-lock-icon-size, var(--mdc-icon-size, 24px));
       }
       #mainContainer {
         height: 100%;
@@ -345,6 +346,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
         padding: 8px 7px;
         border-radius: var(--ha-card-border-radius, 12px);
         background: var(--restriction-overlay-background, unset);
+        --lock-icon-size: var(--restriction-lock-icon-size, var(--mdc-icon-size, 24px));
       }
       #overlay.has-row #subContainer {
         border-radius: var(--restriction-overlay-row-border-radius, 0) !important;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface RestrictionCardConfig extends LovelaceCardConfig {
   action?: string;
   locked_icon?: string;
   unlocked_icon?: string;
-  css_variables?: string;
+  css_variables?: {};
 }
 
 export interface RestrictionsConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface RestrictionCardConfig extends LovelaceCardConfig {
   action?: string;
   locked_icon?: string;
   unlocked_icon?: string;
+  css_variables?: string;
 }
 
 export interface RestrictionsConfig {


### PR DESCRIPTION
The `css_variables` option can be used to override default values of supported theme variables w/o using a custom theme or card-mod.