### PR TITLE
feat: fallback to a standard prompt popup

### DIFF
--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -227,20 +227,26 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
       if (this._config.restrictions.pin && this._matchRestriction(this._config.restrictions.pin)) {
         const isMultiplePins = Array.isArray(this._config.restrictions.pin.code);
-        const regex = /^\d+$/;
-        let codeFormat;
-        if (!isMultiplePins) {
-          const asString = this._config.restrictions.pin.code as string;
-          codeFormat = regex.test(asString) ? 'number' : 'text';
+        let pin;
+        const titleDialog = this._config.restrictions.pin.text || 'Input pin code';
+        if (this._helpers?.showEnterCodeDialog) {
+          const regex = /^\d+$/;
+          let codeFormat;
+          if (!isMultiplePins) {
+            const asString = this._config.restrictions.pin.code as string;
+            codeFormat = regex.test(asString) ? 'number' : 'text';
+          } else {
+            const asArray = this._config.restrictions.pin.code as string[];
+            codeFormat = regex.test(asArray.join('')) ? 'number' : 'text';
+          }
+          pin = await this._helpers.showEnterCodeDialog(lock, {
+            codeFormat: codeFormat,
+            title: titleDialog,
+            submitText: 'OK',
+          });
         } else {
-          const asArray = this._config.restrictions.pin.code as string[];
-          codeFormat = regex.test(asArray.join('')) ? 'number' : 'text';
+          pin = prompt(titleDialog);
         }
-        const pin = await this._helpers.showEnterCodeDialog(lock, {
-          codeFormat: codeFormat,
-          title: this._config.restrictions.pin.text || 'Input pin code',
-          submitText: 'OK',
-        });
 
         let conditionString = false;
         if (!isMultiplePins) conditionString = pin != (this._config.restrictions.pin.code as string);


### PR DESCRIPTION
For old HA versions, a standard popup will be shown.

Tested in 2023.7.1:
```
type: custom:restriction-card
card:
  type: entity
  entity: sun.sun
restrictions:
  pin:
    code: 1234
    text: Enter 1234
```
![image](https://github.com/user-attachments/assets/a83d467c-6543-43a4-a3c6-5c5fc3814fc1)

In 2025.6.3:
![image](https://github.com/user-attachments/assets/20c6f1e3-5bc8-420c-a7ee-d66c43c82802)
