### PR TITLE
fix: await updateComplete before hiding icon so unlocked_icon renders first

### DIFF
--- a/src/restriction-card.ts
+++ b/src/restriction-card.ts
@@ -312,6 +312,7 @@ class RestrictionCard extends LitElement implements LovelaceCard {
 
     this._unlocked = true;
     overlay.style.setProperty('pointer-events', 'none');
+    await this.updateComplete;
     lock.classList.add('icon-hidden');
     overlay.classList.add('unlocked');
     overlay.classList.remove('locked');


### PR DESCRIPTION
Fixes #183

When `_unlocked` is set to `true`, Lit schedules an async re-render to show the `unlocked_icon`. Previously, `icon-hidden` was added synchronously before that re-render could complete, so the `unlocked_icon` was always hidden before it ever appeared. Awaiting `updateComplete` ensures the re-render runs first, making the `unlocked_icon` briefly visible before fading out.

Generated with [Claude Code](https://claude.ai/code)