### PR TITLE
fix: prevent scrollbar glitch on hold action ripple animation

### DIFF
--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -36,7 +36,7 @@ class ActionHandler extends HTMLElement implements ActionHandler {
 
   public connectedCallback(): void {
     Object.assign(this.style, {
-      position: 'absolute',
+      position: 'fixed',
       width: isTouch ? '100px' : '50px',
       height: isTouch ? '100px' : '50px',
       transform: 'translate(-50%, -50%)',
@@ -84,11 +84,11 @@ class ActionHandler extends HTMLElement implements ActionHandler {
       let x;
       let y;
       if ((ev as TouchEvent).touches) {
-        x = (ev as TouchEvent).touches[0].pageX;
-        y = (ev as TouchEvent).touches[0].pageY;
+        x = (ev as TouchEvent).touches[0].clientX;
+        y = (ev as TouchEvent).touches[0].clientY;
       } else {
-        x = (ev as MouseEvent).pageX;
-        y = (ev as MouseEvent).pageY;
+        x = (ev as MouseEvent).clientX;
+        y = (ev as MouseEvent).clientY;
       }
 
       this.timer = window.setTimeout(() => {


### PR DESCRIPTION
Fixes #187

The `action-handler-restriction` ripple element was using `position: absolute` with `pageX/pageY` coordinates. When a hold was triggered near the viewport edge, the element could extend past the viewport, forcing the browser to expand the scroll area and briefly show a scrollbar.

Changes:
- `position: 'absolute'` → `position: 'fixed'` so the ripple is viewport-constrained
- `pageX/pageY` → `clientX/clientY` to match the fixed positioning

Generated with [Claude Code](https://claude.ai/code)