### PR TITLE
fix #193: prevent scrollbar glitch on hold action ripple animation

### DIFF
--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -275,7 +275,7 @@ const getActionHandler = (): ActionHandler => {
 
   const div = document.createElement('div');
   div.className = 'action-handler-restriction-card';
-  div.style.position = 'absolute';
+  div.style.position = 'fixed';
   div.style.width = isTouch ? '100px' : '50px';
   div.style.height = isTouch ? '100px' : '50px';
   div.style.transform = 'translate(-50%, -50%) scale(0)';


### PR DESCRIPTION
**The Problem:**
When a user holds down on the card, a circular ripple animation (`<div class="action-handler-restriction-card">`) is created and temporarily attached to the document body to visually indicate the interaction. 
In `src/action-handler-directive.ts`, this element was styled with `position: absolute;` and its position was set using `clientX` and `clientY` (which are coordinates relative to the viewport). 
Because `position: absolute;` positions the element relative to the document body, placing the ripple near the bottom or right edge of the screen could temporarily push the document's boundaries outward as it animated with `scale(1)`. This mismatch between viewport coordinates and document positioning caused the browser to suddenly render scrollbars and shift the view until the animation completed and the element was hidden.

**The Solution:**
I changed the positioning of the ripple element from `position: absolute` to `position: fixed`.
```typescript
  const div = document.createElement('div');
  div.className = 'action-handler-restriction-card';
- div.style.position = 'absolute';
+ div.style.position = 'fixed';
```
Since `position: fixed` works exactly with viewport coordinates (`clientX`/`clientY`) and is bound by the viewport edge, the ripple animation now correctly appears exactly where the user taps and will no longer artificially expand the document to cause random scrollbars.

- Gemini 3.1 Pro